### PR TITLE
docs: fix usage steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Discover why users choose Apsara as the design system for their projects
 Explore the [Storybook](https://odpf.github.io/apsara/) to learn about all the Apsara components.
 
 ```sh
-$ yarn add odpf/apsara
+$ yarn add @odpf/apsara
 # or
-$ npm install --save odpf/apsara
+$ npm install --save @odpf/apsara
 ```
 
 Use Apsara components inside your react project


### PR DESCRIPTION
The usage steps mentioned in the README do not work when installing and importing the library in a boilerplate app created using `create-react-app` command.

This PR fixes that by adding `@` symbol for scopes while adding the module.