### PR TITLE
feat(Form): add example to use with Tabs

### DIFF
--- a/packages/apsara-ui/src/FormBuilder/FormBuilder.stories.tsx
+++ b/packages/apsara-ui/src/FormBuilder/FormBuilder.stories.tsx
@@ -1,5 +1,7 @@
-import React, { FC } from "react";
-import FormBuilder from "./index";
+import React, { FC, useEffect } from "react";
+
+import FormBuilder, { Form, Field } from "./index";
+import Tabs from "../Tabs";
 import Button from "../Button";
 
 export default {
@@ -7,7 +9,7 @@ export default {
     component: FormBuilder,
 };
 
-export const Form: FC = () => {
+export const Basic: FC = () => {
     const [form] = FormBuilder.useForm();
     const forceUpdate = FormBuilder.useForceUpdate();
     const accountTypeOptions = [
@@ -85,3 +87,66 @@ export const Form: FC = () => {
         </div>
     );
 };
+
+export const WithTabs = () => {
+    const [form] = Form.useForm()
+
+    useEffect(() => {
+        form.setFieldsValue({
+            name: 'Test',
+            hobbies: [
+                { label: 'drawing', since: '2yo' },
+                { label: 'cooking', since: '5yo' },
+            ],
+        })
+    }, [])
+
+    const onFinish = () => {
+        // we need to pass `true` to form.getFieldsValue(true) to make sure we all the fields from the form
+        // not passing `true` will only give you the fields that are currently rendered
+        console.log('form values:', form.getFieldsValue(true))
+    }
+
+    return (
+        <Form form={form} onFinish={onFinish}>
+            <Tabs
+                tabContent={[
+                    {
+                        title: 'General',
+                        value: 'general_tab',
+                        content: (
+                            <div>
+                                <Field name="name">
+                                    <input placeholder="Sample Name" />
+                                </Field>
+                            </div>
+                        ),
+                    },
+                    {
+                        title: 'Hobbies',
+                        value: 'hobby_tab',
+                        content: (
+                            <div>
+                                <Form.List name="hobbies">
+                                    {(fields) => fields.map((field) => (
+                                        <>
+                                            <Field name={[field.name, 'label']}>
+                                                <input placeholder="Label" />
+                                            </Field>
+                                            <Field name={[field.name, 'since']}>
+                                                <input placeholder="Since" />
+                                            </Field>
+                                            <br />
+                                        </>
+                                    ))}
+                                </Form.List>
+                            </div>
+                        ),
+                    }
+                ]}
+            />
+            <button>Submit</button>
+        </Form>
+
+    )
+}

--- a/packages/apsara-ui/src/FormBuilder/index.tsx
+++ b/packages/apsara-ui/src/FormBuilder/index.tsx
@@ -4,7 +4,7 @@ import InternalForm, { FormInstance, FormProps, useForm } from "./Form";
 import FormBuilderItems from "./FormBuilderItems";
 import Item from "./FormItem";
 import PropTypes from "prop-types";
-import { List } from "rc-field-form";
+import { List, Field } from "rc-field-form";
 
 type InternalFormType = typeof InternalForm;
 
@@ -66,5 +66,5 @@ CustomForm.useForceUpdate = () => {
     return forceUpdate;
 };
 
-export { Form, FormInstance };
+export { Form, FormInstance, Field };
 export default CustomForm;


### PR DESCRIPTION
Add an example to use `Form` components with `Tabs`. One thing to notice how it uses `form.getFieldsValue(true)` to get all the values of the form.

### Issues
`Tabs` will not render content from inactive tabs. It means that form fields that reside in inactive tabs will not be available to form.

Calling `form.getFieldsValue()` will only give you fields that are being rendered which are those inside active tab only.

We need to pass `true` (`form.getFieldsValue(true)`) to make sure it returns all the values inside the form. 