### PR TITLE
fix: support clear naming for Compound Components

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 .next
 dist
 coverage/
+examples/
+apps/
+*.mdx

--- a/components/accordion/index.tsx
+++ b/components/accordion/index.tsx
@@ -7,7 +7,7 @@ const StyledAccordion = styled(AccordionPrimitive.Root, {});
 type AccordionPrimitiveProps = React.ComponentProps<typeof AccordionPrimitive.Root>;
 type AccordionProps = AccordionPrimitiveProps & { css?: CSS };
 
-export const Accordion = React.forwardRef<React.ElementRef<typeof StyledAccordion>, AccordionProps>(
+const AccordionRoot = React.forwardRef<React.ElementRef<typeof StyledAccordion>, AccordionProps>(
     ({ children, ...props }, forwardedRef) => (
         <StyledAccordion ref={forwardedRef} {...props} {...(props.type === "single" ? { collapsible: true } : {})}>
             {children}
@@ -73,7 +73,7 @@ const StyledTrigger = styled(AccordionPrimitive.Trigger, {
 type AccordionTriggerPrimitiveProps = React.ComponentProps<typeof AccordionPrimitive.Trigger>;
 type AccordionTriggerProps = AccordionTriggerPrimitiveProps & { css?: CSS };
 
-export const AccordionTrigger = React.forwardRef<React.ElementRef<typeof StyledTrigger>, AccordionTriggerProps>(
+const AccordionTrigger = React.forwardRef<React.ElementRef<typeof StyledTrigger>, AccordionTriggerProps>(
     ({ children, ...props }, forwardedRef) => (
         <StyledHeader>
             <StyledTrigger {...props} ref={forwardedRef}>
@@ -88,5 +88,8 @@ const StyledContent = styled(AccordionPrimitive.Content, {
     padding: "$2",
 });
 
-export const AccordionItem = StyledItem;
-export const AccordionContent = StyledContent;
+export const Accordion = Object.assign(AccordionRoot, {
+    Item: StyledItem,
+    Content: StyledContent,
+    Trigger: AccordionTrigger,
+});

--- a/components/alertdialog/index.tsx
+++ b/components/alertdialog/index.tsx
@@ -4,9 +4,6 @@ import { CSS, styled } from "../../stitches.config";
 import { overlayStyles } from "../overlay";
 import { panelStyles } from "../panel";
 
-const AlertDialog = AlertDialogPrimitive.Root;
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
-
 const StyledOverlay = styled(AlertDialogPrimitive.Overlay, overlayStyles, {
     position: "fixed",
     top: 0,
@@ -44,17 +41,11 @@ const AlertDialogContent = React.forwardRef<React.ElementRef<typeof StyledConten
     ),
 );
 
-const AlertDialogTitle = AlertDialogPrimitive.Title;
-const AlertDialogDescription = AlertDialogPrimitive.Description;
-const AlertDialogAction = AlertDialogPrimitive.Action;
-const AlertDialogCancel = AlertDialogPrimitive.Cancel;
-
-export {
-    AlertDialog,
-    AlertDialogTrigger,
-    AlertDialogContent,
-    AlertDialogTitle,
-    AlertDialogDescription,
-    AlertDialogAction,
-    AlertDialogCancel,
-};
+export const AlertDialog = Object.assign(AlertDialogPrimitive.Root, {
+    Content: AlertDialogContent,
+    Trigger: AlertDialogPrimitive.Trigger,
+    Title: AlertDialogPrimitive.Title,
+    Description: AlertDialogPrimitive.Description,
+    Action: AlertDialogPrimitive.Action,
+    Cancel: AlertDialogPrimitive.Cancel,
+});

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -226,12 +226,12 @@ const StyledAvatarFallback = styled(AvatarPrimitive.Fallback, {
     },
 });
 
-export const AvatarNestedItem = styled("div", {
+const AvatarNestedItem = styled("div", {
     boxShadow: "0 0 0 2px $colors$loContrast",
     borderRadius: "50%",
 });
 
-export const AvatarGroup = styled("div", {
+const AvatarGroup = styled("div", {
     display: "flex",
     flexDirection: "row-reverse",
     [`& ${AvatarNestedItem}:nth-child(n+2)`]: {
@@ -253,7 +253,7 @@ type AvatarOwnProps = AvatarPrimitiveProps &
         status?: StatusColors["variant"];
     };
 
-export const Avatar = React.forwardRef<React.ElementRef<typeof StyledAvatar>, AvatarOwnProps>(
+const AvatarRoot = React.forwardRef<React.ElementRef<typeof StyledAvatar>, AvatarOwnProps>(
     ({ alt, src, fallback, size, variant, shape, css, status, ...props }, forwardedRef) => {
         return (
             <Box
@@ -287,3 +287,10 @@ export const Avatar = React.forwardRef<React.ElementRef<typeof StyledAvatar>, Av
         );
     },
 );
+
+export const Avatar = Object.assign(AvatarRoot, {
+    Image: StyledAvatarImage,
+    Fallback: StyledAvatarFallback,
+    Group: AvatarGroup,
+    NestedItem: AvatarNestedItem,
+});

--- a/components/bedge/index.tsx
+++ b/components/bedge/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { CSS, styled } from "~/stitches.config";
 import { Flex } from "../flex";
 
-export const Badge = styled("span", {
+const StyledBadge = styled("span", {
     // Reset
     alignItems: "center",
     appearance: "none",
@@ -464,10 +464,14 @@ const StyledVerifiedBadge = styled("div", Flex, {
 
 type VerifiedBadgeProps = React.ComponentProps<typeof StyledVerifiedBadge> & { css?: CSS };
 
-export const VerifiedBadge = React.forwardRef<React.ElementRef<typeof StyledVerifiedBadge>, VerifiedBadgeProps>(
+const VerifiedBadge = React.forwardRef<React.ElementRef<typeof StyledVerifiedBadge>, VerifiedBadgeProps>(
     (props, forwardedRef) => (
         <StyledVerifiedBadge {...props} ref={forwardedRef}>
             <CheckIcon />
         </StyledVerifiedBadge>
     ),
 );
+
+export const Badge = Object.assign(StyledBadge, {
+    Verified: VerifiedBadge,
+});

--- a/components/contextmenu/index.tsx
+++ b/components/contextmenu/index.tsx
@@ -7,9 +7,6 @@ import { Flex } from "../flex";
 import { itemCss, labelCss, menuCss, separatorCss } from "../menu";
 import { panelStyles } from "../panel";
 
-const ContextMenu = ContextMenuPrimitive.Root;
-const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
-
 const StyledContent = styled(ContextMenuPrimitive.Content, menuCss, panelStyles);
 
 type ContextMenuContentPrimitiveProps = React.ComponentProps<typeof ContextMenuPrimitive.Content>;
@@ -76,15 +73,14 @@ const ContextMenuRadioItem = React.forwardRef<
     </StyledContextMenuRadioItem>
 ));
 
-export {
-    ContextMenu,
-    ContextMenuTrigger,
-    ContextMenuContent,
-    ContextMenuItem,
-    ContextMenuGroup,
-    ContextMenuLabel,
-    ContextMenuSeparator,
-    ContextMenuCheckboxItem,
-    ContextMenuRadioGroup,
-    ContextMenuRadioItem,
-};
+export const ContextMenu = Object.assign(ContextMenuPrimitive.Root, {
+    Trigger: ContextMenuPrimitive.Trigger,
+    Content: ContextMenuContent,
+    Item: ContextMenuItem,
+    Group: ContextMenuGroup,
+    Label: ContextMenuLabel,
+    Separator: ContextMenuSeparator,
+    CheckboxItem: ContextMenuCheckboxItem,
+    RadioGroup: ContextMenuRadioGroup,
+    RadioItem: ContextMenuRadioItem,
+});

--- a/components/dialog/index.tsx
+++ b/components/dialog/index.tsx
@@ -6,9 +6,6 @@ import { IconButton } from "../button";
 import { overlayStyles } from "../overlay";
 import { panelStyles } from "../panel";
 
-const Dialog = DialogPrimitive.Root;
-const DialogTrigger = DialogPrimitive.Trigger;
-
 const StyledOverlay = styled(DialogPrimitive.Overlay, overlayStyles, {
     position: "fixed",
     top: 0,
@@ -64,8 +61,10 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof StyledContent>, D
     ),
 );
 
-const DialogClose = DialogPrimitive.Close;
-const DialogTitle = DialogPrimitive.Title;
-const DialogDescription = DialogPrimitive.Description;
-
-export { Dialog, DialogTrigger, DialogContent, DialogClose, DialogTitle, DialogDescription };
+export const Dialog = Object.assign(DialogPrimitive.Root, {
+    Trigger: DialogPrimitive.Trigger,
+    Content: DialogContent,
+    Close: DialogPrimitive.Close,
+    Title: DialogPrimitive.Title,
+    Description: DialogPrimitive.Description,
+});

--- a/components/dropdownmenu/index.tsx
+++ b/components/dropdownmenu/index.tsx
@@ -7,9 +7,6 @@ import { Flex } from "../flex";
 import { itemCss, labelCss, menuCss, separatorCss } from "../menu";
 import { panelStyles } from "../panel";
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
-
 const StyledContent = styled(DropdownMenuPrimitive.Content, menuCss, panelStyles);
 
 type DropdownMenuContentPrimitiveProps = React.ComponentProps<typeof DropdownMenuPrimitive.Content>;
@@ -76,15 +73,14 @@ const DropdownMenuRadioItem = React.forwardRef<
     </StyledDropdownMenuRadioItem>
 ));
 
-export {
-    DropdownMenu,
-    DropdownMenuTrigger,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuGroup,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuCheckboxItem,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-};
+export const DropdownMenu = Object.assign(DropdownMenuPrimitive.Root, {
+    Trigger: DropdownMenuPrimitive.Trigger,
+    Content: DropdownMenuContent,
+    Item: DropdownMenuItem,
+    Group: DropdownMenuGroup,
+    Label: DropdownMenuLabel,
+    Separator: DropdownMenuSeparator,
+    CheckboxItem: DropdownMenuCheckboxItem,
+    RadioGroup: DropdownMenuRadioGroup,
+    RadioItem: DropdownMenuRadioItem,
+});

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -52,19 +52,19 @@ export const separatorCss = css({
     backgroundColor: "$slate6",
 });
 
-export const Menu = styled(MenuPrimitive.Root, menuCss);
-export const MenuContent = styled(MenuPrimitive.Content, panelStyles);
+const MenuRoot = styled(MenuPrimitive.Root, menuCss);
+const MenuContent = styled(MenuPrimitive.Content, panelStyles);
 
-export const MenuSeparator = styled(MenuPrimitive.Separator, separatorCss);
+const MenuSeparator = styled(MenuPrimitive.Separator, separatorCss);
 
-export const MenuItem = styled(MenuPrimitive.Item, itemCss);
+const MenuItem = styled(MenuPrimitive.Item, itemCss);
 
 const StyledMenuRadioItem = styled(MenuPrimitive.RadioItem, itemCss);
 
 type MenuRadioItemPrimitiveProps = React.ComponentProps<typeof MenuPrimitive.RadioItem>;
 type MenuRadioItemProps = MenuRadioItemPrimitiveProps & { css?: CSS };
 
-export const MenuRadioItem = React.forwardRef<React.ElementRef<typeof StyledMenuRadioItem>, MenuRadioItemProps>(
+const MenuRadioItem = React.forwardRef<React.ElementRef<typeof StyledMenuRadioItem>, MenuRadioItemProps>(
     ({ children, ...props }, forwardedRef) => (
         <StyledMenuRadioItem {...props} ref={forwardedRef}>
             <Box as="span" css={{ position: "absolute", left: "$1" }}>
@@ -91,20 +91,30 @@ const StyledMenuCheckboxItem = styled(MenuPrimitive.CheckboxItem, itemCss);
 type MenuCheckboxItemPrimitiveProps = React.ComponentProps<typeof MenuPrimitive.CheckboxItem>;
 type MenuCheckboxItemProps = MenuCheckboxItemPrimitiveProps & { css?: CSS };
 
-export const MenuCheckboxItem = React.forwardRef<
-    React.ElementRef<typeof StyledMenuCheckboxItem>,
-    MenuCheckboxItemProps
->(({ children, ...props }, forwardedRef) => (
-    <StyledMenuCheckboxItem {...props} ref={forwardedRef}>
-        <Box as="span" css={{ position: "absolute", left: "$1" }}>
-            <MenuPrimitive.ItemIndicator>
-                <CheckIcon />
-            </MenuPrimitive.ItemIndicator>
-        </Box>
-        {children}
-    </StyledMenuCheckboxItem>
-));
+const MenuCheckboxItem = React.forwardRef<React.ElementRef<typeof StyledMenuCheckboxItem>, MenuCheckboxItemProps>(
+    ({ children, ...props }, forwardedRef) => (
+        <StyledMenuCheckboxItem {...props} ref={forwardedRef}>
+            <Box as="span" css={{ position: "absolute", left: "$1" }}>
+                <MenuPrimitive.ItemIndicator>
+                    <CheckIcon />
+                </MenuPrimitive.ItemIndicator>
+            </Box>
+            {children}
+        </StyledMenuCheckboxItem>
+    ),
+);
 
-export const MenuLabel = styled(MenuPrimitive.Label, labelCss);
-export const MenuRadioGroup = styled(MenuPrimitive.RadioGroup, {});
-export const MenuGroup = styled(MenuPrimitive.Group, {});
+const MenuLabel = styled(MenuPrimitive.Label, labelCss);
+const MenuRadioGroup = styled(MenuPrimitive.RadioGroup, {});
+const MenuGroup = styled(MenuPrimitive.Group, {});
+
+export const Menu = Object.assign(MenuRoot, {
+    Content: MenuContent,
+    Separator: MenuSeparator,
+    Item: MenuItem,
+    RadioItem: MenuRadioItem,
+    CheckboxItem: MenuCheckboxItem,
+    Label: MenuLabel,
+    Group: MenuGroup,
+    RadioGroup: MenuRadioGroup,
+});

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -4,9 +4,6 @@ import { CSS, styled } from "../../stitches.config";
 import { Box } from "../box";
 import { panelStyles } from "../panel";
 
-const Popover = PopoverPrimitive.Root;
-const PopoverTrigger = PopoverPrimitive.Trigger;
-
 const StyledContent = styled(PopoverPrimitive.Content, panelStyles, {
     minWidth: 200,
     minHeight: "$6",
@@ -34,6 +31,8 @@ const PopoverContent = React.forwardRef<React.ElementRef<typeof StyledContent>, 
     ),
 );
 
-const PopoverClose = PopoverPrimitive.Close;
-
-export { Popover, PopoverTrigger, PopoverContent, PopoverClose };
+export const Popover = Object.assign(PopoverPrimitive.Root, {
+    Trigger: PopoverPrimitive.Trigger,
+    Content: PopoverContent,
+    Close: PopoverPrimitive.Close,
+});

--- a/components/radio/index.tsx
+++ b/components/radio/index.tsx
@@ -2,7 +2,7 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import React from "react";
 import { CSS, styled, VariantProps } from "~/stitches.config";
 
-export const RadioGroup = styled(RadioGroupPrimitive.Root, {
+export const RadioRoot = styled(RadioGroupPrimitive.Root, {
     display: "flex",
 });
 
@@ -87,8 +87,13 @@ type RadioVariants = VariantProps<typeof StyledRadio>;
 type RadioGroupItemPrimitiveProps = React.ComponentProps<typeof RadioGroupPrimitive.Item>;
 type RadioProps = RadioGroupItemPrimitiveProps & RadioVariants & { css?: CSS };
 
-export const Radio = React.forwardRef<React.ElementRef<typeof StyledRadio>, RadioProps>((props, forwardedRef) => (
+const RadioItem = React.forwardRef<React.ElementRef<typeof StyledRadio>, RadioProps>((props, forwardedRef) => (
     <StyledRadio {...props} ref={forwardedRef}>
         <StyledIndicator />
     </StyledRadio>
 ));
+
+export const Radio = Object.assign(RadioRoot, {
+    Indicator: StyledIndicator,
+    Item: RadioItem,
+});

--- a/components/radiocard/index.tsx
+++ b/components/radiocard/index.tsx
@@ -2,7 +2,7 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import React from "react";
 import { CSS, styled } from "~/stitches.config";
 
-export const RadioCardGroup = styled(RadioGroupPrimitive.Root, {
+const RadioGroupRoot = styled(RadioGroupPrimitive.Root, {
     display: "block",
 });
 
@@ -67,3 +67,7 @@ export const RadioCard = React.forwardRef<React.ElementRef<typeof StyledRadio>, 
         </StyledRadio>
     ),
 );
+
+export const RadioGroup = Object.assign(RadioGroupRoot, {
+    Card: RadioCard,
+});

--- a/components/sheet/index.tsx
+++ b/components/sheet/index.tsx
@@ -5,9 +5,6 @@ import { CSS, keyframes, styled, VariantProps } from "~/stitches.config";
 import { IconButton } from "../button";
 import { overlayStyles } from "../overlay";
 
-const Sheet = DialogPrimitive.Root;
-const SheetTrigger = DialogPrimitive.Trigger;
-
 const fadeIn = keyframes({
     from: { opacity: "0" },
     to: { opacity: "1" },
@@ -123,8 +120,10 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof StyledContent>, Sh
     ),
 );
 
-const SheetClose = DialogPrimitive.Close;
-const SheetTitle = DialogPrimitive.Title;
-const SheetDescription = DialogPrimitive.Description;
-
-export { Sheet, SheetTrigger, SheetContent, SheetClose, SheetTitle, SheetDescription };
+export const Sheet = Object.assign(DialogPrimitive.Root, {
+    Trigger: DialogPrimitive.Trigger,
+    Content: SheetContent,
+    Close: DialogPrimitive.Close,
+    Title: DialogPrimitive.Title,
+    Description: DialogPrimitive.Description,
+});

--- a/components/table/filter/FilteredChip.tsx
+++ b/components/table/filter/FilteredChip.tsx
@@ -3,13 +3,7 @@ import type { Column, RowData } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import React from "react";
 import { Box } from "~/components/box";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "~/components/dropdownmenu";
+import { DropdownMenu } from "~/components/dropdownmenu";
 import { Flex } from "~/components/flex";
 import { Text } from "~/components/text";
 import type { TableColumnMetadata } from "~/types/types";
@@ -114,20 +108,20 @@ type ColumnDropdownProps = {
 
 const ColumnDropdown = ({ index, name, data, onMenuSelect, selectKey }: ColumnDropdownProps) => (
     <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+        <DropdownMenu.Trigger asChild>
             <Text css={{ padding: "$1 $2", lineHeight: "normal" }}>{name}</Text>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-            <DropdownMenuGroup>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="start">
+            <DropdownMenu.Group>
                 {data.map((column, _index) => (
-                    <DropdownMenuItem
+                    <DropdownMenu.Item
                         key={`${column.key}_${_index}`}
                         onSelect={() => onMenuSelect(index, selectKey, column.value)}
                     >
                         {column.name}
-                    </DropdownMenuItem>
+                    </DropdownMenu.Item>
                 ))}
-            </DropdownMenuGroup>
-        </DropdownMenuContent>
+            </DropdownMenu.Group>
+        </DropdownMenu.Content>
     </DropdownMenu>
 );

--- a/components/table/filter/TableColumnFilterSelection.tsx
+++ b/components/table/filter/TableColumnFilterSelection.tsx
@@ -2,13 +2,7 @@ import { innerJoin } from "ramda";
 import type { ReactNode } from "react";
 import React, { useMemo } from "react";
 import type { DropdownMenuContentProps } from "~/components/dropdownmenu";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "~/components/dropdownmenu";
+import { DropdownMenu } from "~/components/dropdownmenu";
 import { useTable } from "../hooks/useTable";
 import { getAllColumnsData } from "../utils/column";
 
@@ -33,18 +27,18 @@ const TableFilterSelection = ({ children, ...props }: TableFilterSelectionProps)
 
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-            <DropdownMenuContent {...props}>
-                <DropdownMenuGroup>
+            <DropdownMenu.Trigger asChild>{children}</DropdownMenu.Trigger>
+            <DropdownMenu.Content {...props}>
+                <DropdownMenu.Group>
                     {filteredColumns.map((column, index) => {
                         return (
-                            <DropdownMenuItem key={column.key} onSelect={() => onMenuSelect(column.value)}>
+                            <DropdownMenu.Item key={column.key} onSelect={() => onMenuSelect(column.value)}>
                                 {column.name}
-                            </DropdownMenuItem>
+                            </DropdownMenu.Item>
                         );
                     })}
-                </DropdownMenuGroup>
-            </DropdownMenuContent>
+                </DropdownMenu.Group>
+            </DropdownMenu.Content>
         </DropdownMenu>
     );
 };

--- a/components/table/filter/TableColumnsViewFilter.tsx
+++ b/components/table/filter/TableColumnsViewFilter.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Flex } from "~/components/flex";
 import { Label } from "~/components/label";
-import { Popover, PopoverContent, PopoverTrigger } from "~/components/popover";
+import { Popover } from "~/components/popover";
 import { Separator } from "~/components/separator";
 import { useTable } from "../hooks/useTable";
 
@@ -9,8 +9,8 @@ export default function TableColumnsFilter({ children }: any) {
     const { table } = useTable();
     return (
         <Popover modal>
-            <PopoverTrigger asChild>{children}</PopoverTrigger>
-            <PopoverContent css={{ padding: "$4" }}>
+            <Popover.Trigger asChild>{children}</Popover.Trigger>
+            <Popover.Content css={{ padding: "$4" }}>
                 <Flex direction="column" css={labelContainer}>
                     <Label css={labelStyle}>
                         <input
@@ -38,7 +38,7 @@ export default function TableColumnsFilter({ children }: any) {
                         );
                     })}
                 </Flex>
-            </PopoverContent>
+            </Popover.Content>
         </Popover>
     );
 }

--- a/components/table/index.tsx
+++ b/components/table/index.tsx
@@ -1,19 +1,19 @@
 import { styled } from "~/stitches.config";
 
-export const SimpleCaption = styled("caption", {
+const SimpleCaption = styled("caption", {
     textAlign: "start",
     marginBottom: "$5",
 });
 
-export const SimpleTbody = styled("tbody", {
+const SimpleTbody = styled("tbody", {
     width: "100%",
 });
 
-export const SimpleTfoot = styled("tfoot", {});
+const SimpleTfoot = styled("tfoot", {});
 
-export const SimpleTr = styled("tr", {});
+const SimpleTr = styled("tr", {});
 
-export const SimpleTh = styled("th", {
+const SimpleTh = styled("th", {
     fontWeight: "unset",
     textAlign: "start",
     fontSize: "$2",
@@ -46,7 +46,7 @@ export const SimpleTh = styled("th", {
     },
 });
 
-export const SimpleTd = styled("td", {
+const SimpleTd = styled("td", {
     py: "$2",
     borderBottom: "1px solid $gray4",
     fontSize: "$2",
@@ -78,7 +78,7 @@ export const SimpleTd = styled("td", {
     },
 });
 
-export const SimpleThead = styled("thead", {
+const SimpleThead = styled("thead", {
     [`& ${SimpleTh}`]: {
         fontSize: "$1",
         color: "$gray11",
@@ -89,7 +89,7 @@ export const SimpleThead = styled("thead", {
     },
 });
 
-export const SimpleTable = styled("table", {
+const SimpleTableRoot = styled("table", {
     width: "100%",
     tableLayout: "fixed",
     borderSpacing: 0,
@@ -110,3 +110,13 @@ export const SimpleTable = styled("table", {
 
 export { useTable } from "./hooks/useTable";
 export { Table } from "./Table";
+
+export const SimpleTable = Object.assign(SimpleTableRoot, {
+    Thead: SimpleThead,
+    Td: SimpleTd,
+    Th: SimpleTh,
+    Tr: SimpleTr,
+    Body: SimpleTbody,
+    Footer: SimpleTfoot,
+    Caption: SimpleCaption,
+});

--- a/components/table/inputs/select.tsx
+++ b/components/table/inputs/select.tsx
@@ -5,13 +5,7 @@ import { Text } from "~/components/text";
 import { TextField } from "~/components/textfield";
 
 import React from "react";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "~/components/dropdownmenu";
+import { DropdownMenu } from "~/components/dropdownmenu";
 import type { TableColumnMetadata } from "~/types/types";
 
 type ColumnDropdownProps = {
@@ -38,21 +32,21 @@ const ColumnDropdown = ({ name, data, onMenuSelect, search = true }: ColumnDropd
 
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+            <DropdownMenu.Trigger asChild>
                 <Text css={{ padding: "$1 $2", lineHeight: "normal" }}>{name}</Text>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="start">
                 <Box css={{ px: "$2" }}>
                     <TextField value={searchValue} onChange={onChange} css={{ height: "20px" }} />
                 </Box>
-                <DropdownMenuGroup>
+                <DropdownMenu.Group>
                     {selectValues.map((column, _index) => (
-                        <DropdownMenuItem key={`${column.key}_${_index}`} onSelect={() => onMenuSelect(column.value)}>
+                        <DropdownMenu.Item key={`${column.key}_${_index}`} onSelect={() => onMenuSelect(column.value)}>
                             {column.name}
-                        </DropdownMenuItem>
+                        </DropdownMenu.Item>
                     ))}
-                </DropdownMenuGroup>
-            </DropdownMenuContent>
+                </DropdownMenu.Group>
+            </DropdownMenu.Content>
         </DropdownMenu>
     );
 };

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { CSS, styled } from "../../stitches.config";
 import { Separator } from "../separator";
 
-export const Tabs = styled(TabsPrimitive.Root, {
+const TabsRoot = styled(TabsPrimitive.Root, {
     display: "flex",
     '&[data-orientation="horizontal"]': {
         flexDirection: "column",
     },
 });
 
-export const TabsTrigger = styled(TabsPrimitive.Trigger, {
+const TabsTrigger = styled(TabsPrimitive.Trigger, {
     flexShrink: 0,
     height: "$5",
     display: "inline-flex",
@@ -68,19 +68,23 @@ const StyledTabsList = styled(TabsPrimitive.List, {
 type TabsListPrimitiveProps = React.ComponentProps<typeof TabsPrimitive.List>;
 type TabsListProps = TabsListPrimitiveProps & { css?: CSS };
 
-export const TabsList = React.forwardRef<React.ElementRef<typeof StyledTabsList>, TabsListProps>(
-    (props, forwardedRef) => (
-        <>
-            <StyledTabsList {...props} ref={forwardedRef} />
-            <Separator />
-        </>
-    ),
-);
+const TabsList = React.forwardRef<React.ElementRef<typeof StyledTabsList>, TabsListProps>((props, forwardedRef) => (
+    <>
+        <StyledTabsList {...props} ref={forwardedRef} />
+        <Separator />
+    </>
+));
 
-export const TabsContent = styled(TabsPrimitive.Content, {
+const TabsContent = styled(TabsPrimitive.Content, {
     flexGrow: 1,
     "&:focus": {
         outline: "none",
         boxShadow: "inset 0 0 0 1px $slate8, 0 0 0 1px $slate8",
     },
+});
+
+export const Tabs = Object.assign(TabsRoot, {
+    Trigger: TabsTrigger,
+    Content: TabsContent,
+    List: TabsList,
 });

--- a/index.ts
+++ b/index.ts
@@ -1,50 +1,20 @@
 // components
-export { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./components/accordion";
+export { Accordion } from "./components/accordion";
 export { Alert } from "./components/alert";
-export {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogTitle,
-    AlertDialogTrigger,
-} from "./components/alertdialog";
-export { Avatar, AvatarGroup, AvatarNestedItem } from "./components/avatar";
+export { AlertDialog } from "./components/alertdialog";
+export { Avatar } from "./components/avatar";
 export { Banner } from "./components/banner";
-export { Badge, VerifiedBadge } from "./components/bedge";
+export { Badge } from "./components/bedge";
 export { Box } from "./components/box";
 export { Button } from "./components/button";
 export { Card } from "./components/card";
 export { Checkbox } from "./components/checkbox";
 export { Code } from "./components/code";
 export { Container } from "./components/container";
-export {
-    ContextMenu,
-    ContextMenuCheckboxItem,
-    ContextMenuContent,
-    ContextMenuGroup,
-    ContextMenuItem,
-    ContextMenuLabel,
-    ContextMenuRadioGroup,
-    ContextMenuRadioItem,
-    ContextMenuSeparator,
-    ContextMenuTrigger,
-} from "./components/contextmenu";
+export { ContextMenu } from "./components/contextmenu";
 export { ControlGroup } from "./components/controlgroup";
-export { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from "./components/dialog";
-export {
-    DropdownMenu,
-    DropdownMenuCheckboxItem,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from "./components/dropdownmenu";
+export { Dialog } from "./components/dialog";
+export { DropdownMenu } from "./components/dropdownmenu";
 export { EmptyState } from "./components/emptystate";
 export { Flex } from "./components/flex";
 export { Grid } from "./components/grid";
@@ -53,50 +23,30 @@ export { Image } from "./components/image";
 export { Kbd } from "./components/kbd";
 export { Label } from "./components/label";
 export { Link } from "./components/link";
-export {
-    Menu,
-    MenuCheckboxItem,
-    MenuGroup,
-    MenuItem,
-    MenuLabel,
-    MenuRadioGroup,
-    MenuRadioItem,
-    MenuSeparator,
-} from "./components/menu";
+export { Menu } from "./components/menu";
 export { Overlay } from "./components/overlay";
 export { Panel } from "./components/panel";
 export { Paragraph } from "./components/paragraph";
-export { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "./components/popover";
+export { Popover } from "./components/popover";
 export { ProgressBar } from "./components/progressbar";
-export { Radio, RadioGroup } from "./components/radio";
-export { RadioCard, RadioCardGroup } from "./components/radiocard";
+export { Radio } from "./components/radio";
+export { RadioCard } from "./components/radiocard";
 export { RadioGrid } from "./components/radiogrid";
 export { ScrollArea } from "./components/scrollbar";
 export { SearchField } from "./components/SearchField";
 export { Section } from "./components/section";
 export { Select } from "./components/select";
 export { Separator } from "./components/separator";
-export { Sheet, SheetClose, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from "./components/sheet";
+export { Sheet } from "./components/sheet";
 export { Skeleton } from "./components/skeleton";
 export { Slider } from "./components/slider";
 export { Status } from "./components/status";
 export { Sub } from "./components/sub";
 export { Sup } from "./components/sup";
 export { Switch } from "./components/switch";
-export {
-    SimpleCaption,
-    SimpleTable,
-    SimpleTbody,
-    SimpleTd,
-    SimpleTfoot,
-    SimpleTh,
-    SimpleThead,
-    SimpleTr,
-    Table,
-    useTable,
-} from "./components/table";
+export { SimpleTable, Table, useTable } from "./components/table";
 export { TabLink } from "./components/tablink";
-export { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/tabs";
+export { Tabs } from "./components/tabs";
 export { Text } from "./components/text";
 export { TextArea } from "./components/textarea";
 export { TextField } from "./components/textfield";


### PR DESCRIPTION
In React, compound components are a pattern for creating reusable components that have a parent component with multiple child components that work together to provide a specific functionality. The use of compound components provides flexibility to the developers in terms of customization, reusability, and maintainability of the codebase.

When it comes to creating compound components using menus in React, there are two approaches to create menu items: using `<MenuItem>` or `<Menu.Item>`

**Pros of using `<Menu.Item>`**

1. Clear naming: Using `<Menu.Item>` makes it clear that the component is a child of the <Menu> component.
2. Context awareness: Since `<Menu.Item>` is a child of `<Menu>`, it has access to the context of the parent component. This can be useful when creating more complex menu items.